### PR TITLE
Update bitmap.py to create a new array from file

### DIFF
--- a/src/bitmap.py
+++ b/src/bitmap.py
@@ -253,6 +253,7 @@ class BitMap(object):
         else:
             bm = cls(maxnum)
             file = open(path, 'rb')
+            bm.bitmap = array.array('B')
             bm.bitmap.fromfile(file, (maxnum + 7) // 8)
             file.close()
             return bm


### PR DESCRIPTION
The original implementation could cause the bitmap size to double in some contexts because https://docs.python.org/3/library/array.html#array.array.fromfile states:

> Read n items (as machine values) from the file object f and *append* them to the end of the array. If less than n items are available, EOFError is raised, but the items that were available are still inserted into the array.