### PR TITLE
Use itertools.repeat for initialization instead of list comprehension

### DIFF
--- a/src/bitmap.py
+++ b/src/bitmap.py
@@ -11,6 +11,7 @@
 """
 
 import array
+import itertools
 try:
     from past.builtins import range
 except ImportError:
@@ -34,7 +35,7 @@ class BitMap(object):
         if bitmap:
             self.bitmap = bytearray(bitmap)
         else:
-            self.bitmap = array.array('B', [bit_value for i in range(nbytes)])
+            self.bitmap = array.array('B', itertools.repeat(bit_value, times=nbytes))
 
     def __del__(self):
         """


### PR DESCRIPTION
Use `itertools.repeat` for initialization instead of list comprehension.
This initialization method is more RAM efficient, no list needs to be constructed and stored in RAM during initialization.

It is also faster (new implementation in orange; tested with Python 3.8.10, Linux, Zen 3):

![init with itertools test](https://github.com/wbarnha/bitmap/assets/30833038/1b0ffc24-fcd6-4e31-b0f3-e5b90c5024fc)

Here is the code to produce this graph:
```python3
import matplotlib.pyplot as plt

import time

def get_n_often(s, t):
    start_time = time.time()
    for i in range(t):
        o = BitMap(s)
    time_diff = time.time() - start_time
    return time_diff


def get_m_often(s, t):
    start_time = time.time()
    for i in range(t):
        o = BitMap(s, ram_efficient_init=True)
    time_diff = time.time() - start_time
    return time_diff


x = [8, 32, 128, 512, 2048, 8192, 32768, 131072, 524288, 2097152]
ts = [10000000, 10000000, 1000000, 100000, 10000, 10000, 10000, 10000, 10000, 10000]
ts_factor = [1000, 1000, 100, 10, 1, 1, 1, 1, 1, 1]  # normalization factor

def get_y_n():
	y = []
	for i in range(len(x)):
		y.append(get_n_often(x[i], ts[i]) / ts_factor[i])
	return y


def get_y_m():
	y = []
	for i in range(len(x)):
		y.append(get_m_often(x[i], ts[i]) / ts_factor[i])
	return y

y_n = get_y_n()
y_m = get_y_m()

plt.plot(x, y_n, label="normal")
plt.plot(x, y_m, label="modified")
plt.ylabel("seconds per 10000 initializations")
plt.xlabel("initialization size")
plt.xscale("log")
plt.yscale("log")
plt.legend()

plt.show()
```

(I first added the new initialization implementation with the parameter `ram_efficient_init` and produced the graph with that.)